### PR TITLE
Fix closing brace in mcp

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -130,3 +130,5 @@ export class RogerioMCP extends McpAgent {
 		return results
 	}
 
+
+}


### PR DESCRIPTION
## Summary
- close `RogerioMCP` class definition

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint:fix` *(fails: biome not found)*
- `npm run build` *(fails: Missing script: "build")*

------
https://chatgpt.com/codex/tasks/task_e_68400ebfe2c483258a0c0a31d4674cdb