### PR TITLE
Add NotFound page component

### DIFF
--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import Layout from './Layout'
+
+function NotFoundPage() {
+        return (
+                <Layout
+                        title="Page Not Found"
+                        description="The page you are looking for does not exist."
+                        canonicalUrl="https://rgllm.com/404"
+                >
+                        <h2 className="text-2xl font-bold mb-4">Page Not Found</h2>
+                        <p>Sorry, the page you were looking for doesn’t exist.</p>
+                </Layout>
+        )
+}
+
+export default NotFoundPage

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import indexPage from './pages/index';
 import automovelonlinePage from './pages/automovelonline';
 import { RogerioMCP } from './mcp'
 import { htmlResponse } from './utils/response';
+import NotFoundPage from './components/NotFoundPage';
+import { generateHtml } from './utils/generateHtml';
 export { RogerioMCP } 
 
 type RouteHandler = () => Response | Promise<Response>
@@ -30,11 +32,12 @@ export default <ExportedHandler>{
 		return env.ASSETS.fetch(request)
 	  }
   
-	  if (pathname in pageRoutes) {
-		return pageRoutes[pathname]()
-	  }
-  
-	  return htmlResponse('404', {status: 404})
-	},
+          if (pathname in pageRoutes) {
+                return pageRoutes[pathname]()
+          }
+
+          const html = await generateHtml(NotFoundPage)
+          return htmlResponse(html, {status: 404})
+        },
   }
 


### PR DESCRIPTION
## Summary
- add friendly NotFoundPage component
- render NotFoundPage for unmatched routes

## Testing
- `npm run lint:fix` *(fails: biome not found)*
- `npm test` *(fails: missing script)*
- `npx tsc -p tsconfig.json` *(fails: src/mcp.ts parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68400e3bb0b0832580c2b878d53b3bdb