### PR TITLE
Remove unnecessary async from HTML generation

### DIFF
--- a/src/pages/automovelonline.tsx
+++ b/src/pages/automovelonline.tsx
@@ -3,7 +3,7 @@ import { generateHtml } from '../utils/generateHtml'
 import { htmlResponse } from '../utils/response'
 
 export default async function automovelonline() {
-        const html = await generateHtml(AutomovelOnlinePage)
+        const html = generateHtml(AutomovelOnlinePage)
         return htmlResponse(html)
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { generateHtml } from '../utils/generateHtml'
 import { htmlResponse } from '../utils/response'
 
 export default async function index() {
-        const html = await generateHtml(IndexPage)
+        const html = generateHtml(IndexPage)
         return htmlResponse(html)
 }
 

--- a/src/utils/generateHtml.tsx
+++ b/src/utils/generateHtml.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { renderToString } from 'react-dom/server'
 
 // We'll use an external CSS file processed at build time
-export async function generateHtml(Component: React.ComponentType) {
+export function generateHtml(Component: React.ComponentType) {
 	// Render the component with Tailwind classes
 	const html = renderToString(<Component />)
 	


### PR DESCRIPTION
## Summary
- update `generateHtml` to be sync
- drop awaits from page handlers
- run `biome format` to keep style consistent

## Testing
- `npx -y biome format . --write`

------
https://chatgpt.com/codex/tasks/task_e_68400e39862c83258915df50cccd076b