### PR TITLE
Add link back home on 404 page

### DIFF
--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -9,7 +9,10 @@ function NotFoundPage() {
                         canonicalUrl="https://rgllm.com/404"
                 >
                         <h2 className="text-2xl font-bold mb-4">Page Not Found</h2>
-                        <p>Sorry, the page you were looking for doesn’t exist.</p>
+                        <p className="mb-4">Sorry, the page you were looking for doesn’t exist.</p>
+                        <p>
+                                <a href="/">Go back home</a>
+                        </p>
                 </Layout>
         )
 }


### PR DESCRIPTION
## Summary
- show a "Go back home" link on the 404 page

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint:fix` *(fails: biome not found)*
- `npm start -- --help`

------
https://chatgpt.com/codex/tasks/task_e_68401177daa08325a6f775768dcb693d